### PR TITLE
 Error handling for FFI

### DIFF
--- a/src/provider/file/inline/posix.rs
+++ b/src/provider/file/inline/posix.rs
@@ -82,7 +82,7 @@ impl Posix {
 
 impl InlineProvider for Posix {
     fn mode(&self, name: &str) -> Result<Output, Error> {
-        let res = try!(fs::metadata(name).map(|m| Output::U32(m.permissions().mode())));
+        let res = try!(fs::metadata(name).map(|m| Output::I32(m.permissions().mode() as i32)));
         Ok(res)
     }
 
@@ -156,7 +156,7 @@ impl InlineProvider for Posix {
 
     fn is_readable(&self, name: &str, whom: Option<&Whom>) -> Result<Output, Error> {
         let mode = try!(self.mode(name));
-        let mode_octal = try!(Output::to_u32(mode));
+        let mode_octal = try!(Output::to_i32(mode));
         let res = match whom {
             Some(w) => {
                 match *w {
@@ -173,7 +173,7 @@ impl InlineProvider for Posix {
 
     fn is_writable(&self, name: &str, whom: Option<&Whom>) -> Result<Output, Error> {
         let mode = try!(self.mode(name));
-        let mode_octal = try!(Output::to_u32(mode));
+        let mode_octal = try!(Output::to_i32(mode));
         let res = match whom {
             Some(w) => {
                 match *w {

--- a/src/provider/file/shell/bsd.rs
+++ b/src/provider/file/shell/bsd.rs
@@ -12,8 +12,8 @@ impl ShellProvider for Bsd {
     fn mode(&self, name: &str, b: &Backend) -> Result<Output, Error> {
         let c = format!("stat -f%Lp {}", name);
         let res = try!(b.run_command(&c));
-        let m = try!(u32::from_str_radix(&res, 8));
-        Ok(Output::U32(m))
+        let m = try!(i32::from_str_radix(&res, 8));
+        Ok(Output::I32(m))
     }
 
     fn box_clone(&self) -> Box<ShellProvider> {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -18,6 +18,7 @@ pub struct HandleFunc {
 
 pub enum Output {
     U32(u32),
+    I32(i32),
     I64(i64),
     Bool(bool),
     Text(String),
@@ -42,6 +43,13 @@ impl Output {
     pub fn to_u32(o: Output) -> Result<u32, error::Error> {
         match o {
             Output::U32(u) => Ok(u),
+            _ => Err(From::from(OutputError)),
+        }
+    }
+
+    pub fn to_i32(o: Output) -> Result<i32, error::Error> {
+        match o {
+            Output::I32(u) => Ok(u),
             _ => Err(From::from(OutputError)),
         }
     }

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -414,16 +414,18 @@ pub extern "C" fn resource_file_is_readable(ptr: *mut File) -> int32_t {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_readable_by_owner(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_is_readable_by_owner(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.is_readable_by_owner().unwrap() {
-        1
-    } else {
-        0
+    match f.is_readable_by_owner() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
     }
 }
 

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -570,23 +570,35 @@ pub extern "C" fn resource_file_is_writable_by_user(ptr: *mut File, u: *const c_
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_md5sum(ptr: *const File) -> *mut c_char {
+pub extern "C" fn resource_file_md5sum(ptr: *mut File) -> *const c_char {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
-    let c = f.md5sum().unwrap();
-    CString::new(c).unwrap().into_raw()
+
+    match f.md5sum() {
+        Ok(c) => CString::new(c).unwrap().into_raw(),
+        Err(e) => {
+            f.error = Some(e);
+            std::ptr::null()
+        }
+    }
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_sha256sum(ptr: *const File) -> *mut c_char {
+pub extern "C" fn resource_file_sha256sum(ptr: *mut File) -> *const c_char {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
-    let c = f.sha256sum().unwrap();
-    CString::new(c).unwrap().into_raw()
+
+    match f.sha256sum() {
+        Ok(c) => CString::new(c).unwrap().into_raw(),
+        Err(e) => {
+            f.error = Some(e);
+            std::ptr::null()
+        }
+    }
 }
 
 #[no_mangle]

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -366,13 +366,19 @@ pub extern "C" fn resource_file_contents(ptr: *mut File) -> *const c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_owner(ptr: *const File) -> *mut c_char {
+pub extern "C" fn resource_file_owner(ptr: *mut File) -> *const c_char {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
-    let c = f.owner().unwrap();
-    CString::new(c).unwrap().into_raw()
+
+    match f.owner() {
+        Ok(c) => CString::new(c).unwrap().into_raw(),
+        Err(e) => {
+            f.error = Some(e);
+            std::ptr::null()
+        }
+    }
 }
 
 #[no_mangle]

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -382,13 +382,19 @@ pub extern "C" fn resource_file_owner(ptr: *mut File) -> *const c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_group(ptr: *const File) -> *mut c_char {
+pub extern "C" fn resource_file_group(ptr: *mut File) -> *const c_char {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
-    let c = f.group().unwrap();
-    CString::new(c).unwrap().into_raw()
+
+    match f.group() {
+        Ok(c) => CString::new(c).unwrap().into_raw(),
+        Err(e) => {
+            f.error = Some(e);
+            std::ptr::null()
+        }
+    }
 }
 
 #[no_mangle]

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -271,13 +271,19 @@ pub extern "C" fn resource_file_is_directory(ptr: *mut File) -> int32_t {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_block_device(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_is_block_device(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.is_block_device().unwrap() { 1 } else { 0 }
+    match f.is_block_device() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
+    }
 }
 
 #[no_mangle]

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -1,15 +1,18 @@
 use backend::Backend;
-use provider::error::Error;
+use provider::error;
 use provider::Provider;
 use provider::Output;
 use libc::{c_char, uint32_t, int64_t};
 use std::ffi::CString;
 use std::ffi::CStr;
+use std;
+use std::error::Error;
 
 pub struct File<'a> {
     name: &'static str,
     backend: &'a Backend,
     provider: &'a Provider,
+    error: Option<error::Error>,
 }
 
 impl<'a> File<'a> {
@@ -18,160 +21,161 @@ impl<'a> File<'a> {
             name: n,
             backend: b,
             provider: p,
+            error: None,
         }
     }
 
-    pub fn mode(&self) -> Result<u32, Error> {
+    pub fn mode(&self) -> Result<u32, error::Error> {
         self.backend
             .handle(self.provider.file.mode(self.name))
             .and_then(Output::to_u32)
     }
 
-    pub fn size(&self) -> Result<i64, Error> {
+    pub fn size(&self) -> Result<i64, error::Error> {
         self.backend
             .handle(self.provider.file.size(self.name))
             .and_then(Output::to_i64)
     }
 
-    pub fn is_file(&self) -> Result<bool, Error> {
+    pub fn is_file(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_file(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn exist(&self) -> Result<bool, Error> {
+    pub fn exist(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.exist(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn is_directory(&self) -> Result<bool, Error> {
+    pub fn is_directory(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_directory(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn is_block_device(&self) -> Result<bool, Error> {
+    pub fn is_block_device(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_block_device(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn is_character_device(&self) -> Result<bool, Error> {
+    pub fn is_character_device(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_character_device(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn is_pipe(&self) -> Result<bool, Error> {
+    pub fn is_pipe(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_pipe(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn is_socket(&self) -> Result<bool, Error> {
+    pub fn is_socket(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_socket(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn is_symlink(&self) -> Result<bool, Error> {
+    pub fn is_symlink(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_symlink(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn contents(&self) -> Result<String, Error> {
+    pub fn contents(&self) -> Result<String, error::Error> {
         self.backend
             .handle(self.provider.file.contents(self.name))
             .and_then(Output::to_string)
     }
 
-    pub fn owner(&self) -> Result<String, Error> {
+    pub fn owner(&self) -> Result<String, error::Error> {
         self.backend
             .handle(self.provider.file.owner(self.name))
             .and_then(Output::to_string)
     }
 
-    pub fn group(&self) -> Result<String, Error> {
+    pub fn group(&self) -> Result<String, error::Error> {
         self.backend
             .handle(self.provider.file.group(self.name))
             .and_then(Output::to_string)
     }
 
-    pub fn linked_to(&self) -> Result<String, Error> {
+    pub fn linked_to(&self) -> Result<String, error::Error> {
         self.backend
             .handle(self.provider.file.linked_to(self.name))
             .and_then(Output::to_string)
     }
 
-    pub fn is_readable(&self) -> Result<bool, Error> {
+    pub fn is_readable(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_readable(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn is_readable_by_owner(&self) -> Result<bool, Error> {
+    pub fn is_readable_by_owner(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_readable_by_owner(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn is_readable_by_group(&self) -> Result<bool, Error> {
+    pub fn is_readable_by_group(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_readable_by_group(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn is_readable_by_others(&self) -> Result<bool, Error> {
+    pub fn is_readable_by_others(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_readable_by_others(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn is_readable_by_user(&self, user: &'static str) -> Result<bool, Error> {
+    pub fn is_readable_by_user(&self, user: &'static str) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_readable_by_user(self.name, user))
             .and_then(Output::to_bool)
     }
 
-    pub fn is_writable(&self) -> Result<bool, Error> {
+    pub fn is_writable(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_writable(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn is_writable_by_owner(&self) -> Result<bool, Error> {
+    pub fn is_writable_by_owner(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_writable_by_owner(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn is_writable_by_group(&self) -> Result<bool, Error> {
+    pub fn is_writable_by_group(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_writable_by_group(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn is_writable_by_others(&self) -> Result<bool, Error> {
+    pub fn is_writable_by_others(&self) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_writable_by_others(self.name))
             .and_then(Output::to_bool)
     }
 
-    pub fn is_writable_by_user(&self, user: &'static str) -> Result<bool, Error> {
+    pub fn is_writable_by_user(&self, user: &'static str) -> Result<bool, error::Error> {
         self.backend
             .handle(self.provider.file.is_writable_by_user(self.name, user))
             .and_then(Output::to_bool)
     }
 
-    pub fn md5sum(&self) -> Result<String, Error> {
+    pub fn md5sum(&self) -> Result<String, error::Error> {
         self.backend
             .handle(self.provider.file.md5sum(self.name))
             .and_then(Output::to_string)
     }
 
-    pub fn sha256sum(&self) -> Result<String, Error> {
+    pub fn sha256sum(&self) -> Result<String, error::Error> {
         self.backend
             .handle(self.provider.file.sha256sum(self.name))
             .and_then(Output::to_string)
@@ -189,6 +193,20 @@ pub extern "C" fn resource_file_free(ptr: *mut File) {
         Box::from_raw(ptr);
     }
 }
+
+#[no_mangle]
+pub extern "C" fn resource_file_error_description(ptr: *const File) -> *const c_char {
+    let f = unsafe {
+        assert!(!ptr.is_null());
+        &*ptr
+    };
+
+    match f.error {
+        Some(ref e) => CString::new(e.description()).unwrap().into_raw(),
+        None => std::ptr::null(),
+    }
+}
+
 
 #[no_mangle]
 pub extern "C" fn resource_file_mode(ptr: *const File) -> uint32_t {

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -240,13 +240,19 @@ pub extern "C" fn resource_file_is_file(ptr: *mut File) -> int32_t {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_exist(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_exist(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.exist().unwrap() { 1 } else { 0 }
+    match f.exist() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
+    }
 }
 
 #[no_mangle]

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -462,12 +462,10 @@ pub extern "C" fn resource_file_is_readable_by_others(ptr: *mut File) -> int32_t
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_readable_by_user(ptr: *const File,
-                                                    u: *const c_char)
-                                                    -> uint32_t {
+pub extern "C" fn resource_file_is_readable_by_user(ptr: *mut File, u: *const c_char) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
     let c_str = unsafe {
@@ -476,10 +474,12 @@ pub extern "C" fn resource_file_is_readable_by_user(ptr: *const File,
     };
 
     let user = c_str.to_str().unwrap();
-    if f.is_readable_by_user(user).unwrap() {
-        1
-    } else {
-        0
+    match f.is_readable_by_user(user) {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
     }
 }
 

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -446,16 +446,18 @@ pub extern "C" fn resource_file_is_readable_by_group(ptr: *mut File) -> int32_t 
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_readable_by_others(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_is_readable_by_others(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.is_readable_by_others().unwrap() {
-        1
-    } else {
-        0
+    match f.is_readable_by_others() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
     }
 }
 

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -215,13 +215,11 @@ pub extern "C" fn resource_file_mode(ptr: *mut File) -> int32_t {
         &mut *ptr
     };
 
-    match f.mode() {
-        Ok(m) => m,
-        Err(e) => {
-            f.error = Some(e);
-            return -1;
-        }
-    }
+    f.mode().unwrap_or_else(|e| {
+        f.error = Some(e);
+        return -1;
+    })
+
 }
 
 #[no_mangle]

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -615,11 +615,17 @@ pub extern "C" fn resource_file_size(ptr: *mut File) -> int64_t {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_linked_to(ptr: *const File) -> *mut c_char {
+pub extern "C" fn resource_file_linked_to(ptr: *mut File) -> *const c_char {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
-    let c = f.linked_to().unwrap();
-    CString::new(c).unwrap().into_raw()
+
+    match f.linked_to() {
+        Ok(c) => CString::new(c).unwrap().into_raw(),
+        Err(e) => {
+            f.error = Some(e);
+            std::ptr::null()
+        }
+    }
 }

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -223,13 +223,20 @@ pub extern "C" fn resource_file_mode(ptr: *mut File) -> int32_t {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_file(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_is_file(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.is_file().unwrap() { 1 } else { 0 }
+    match f.is_file() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
+    }
+
 }
 
 #[no_mangle]

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -335,13 +335,19 @@ pub extern "C" fn resource_file_is_socket(ptr: *mut File) -> int32_t {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_symlink(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_is_symlink(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.is_symlink().unwrap() { 1 } else { 0 }
+    match f.is_symlink() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
+    }
 }
 
 #[no_mangle]

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -287,16 +287,18 @@ pub extern "C" fn resource_file_is_block_device(ptr: *mut File) -> int32_t {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_character_device(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_is_character_device(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.is_character_device().unwrap() {
-        1
-    } else {
-        0
+    match f.is_character_device() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
     }
 }
 

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -303,13 +303,19 @@ pub extern "C" fn resource_file_is_character_device(ptr: *mut File) -> int32_t {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_pipe(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_is_pipe(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.is_pipe().unwrap() { 1 } else { 0 }
+    match f.is_pipe() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
+    }
 }
 
 #[no_mangle]

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -532,16 +532,18 @@ pub extern "C" fn resource_file_is_writable_by_group(ptr: *mut File) -> int32_t 
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_writable_by_others(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_is_writable_by_others(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.is_writable_by_others().unwrap() {
-        1
-    } else {
-        0
+    match f.is_writable_by_others() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
     }
 }
 

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -500,16 +500,18 @@ pub extern "C" fn resource_file_is_writable(ptr: *mut File) -> int32_t {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_writable_by_owner(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_is_writable_by_owner(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.is_writable_by_owner().unwrap() {
-        1
-    } else {
-        0
+    match f.is_writable_by_owner() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
     }
 }
 

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -236,7 +236,6 @@ pub extern "C" fn resource_file_is_file(ptr: *mut File) -> int32_t {
             return -1;
         }
     }
-
 }
 
 #[no_mangle]
@@ -256,13 +255,19 @@ pub extern "C" fn resource_file_exist(ptr: *mut File) -> int32_t {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_directory(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_is_directory(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.is_directory().unwrap() { 1 } else { 0 }
+    match f.is_directory() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
+    }
 }
 
 #[no_mangle]

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -398,13 +398,19 @@ pub extern "C" fn resource_file_group(ptr: *mut File) -> *const c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_readable(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_is_readable(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.is_readable().unwrap() { 1 } else { 0 }
+    match f.is_readable() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
+    }
 }
 
 #[no_mangle]

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -484,13 +484,19 @@ pub extern "C" fn resource_file_is_readable_by_user(ptr: *mut File, u: *const c_
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_writable(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_is_writable(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.is_writable().unwrap() { 1 } else { 0 }
+    match f.is_writable() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
+    }
 }
 
 #[no_mangle]

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -602,13 +602,16 @@ pub extern "C" fn resource_file_sha256sum(ptr: *mut File) -> *const c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_size(ptr: *const File) -> int64_t {
+pub extern "C" fn resource_file_size(ptr: *mut File) -> int64_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    f.size().unwrap()
+    f.size().unwrap_or_else(|e| {
+        f.error = Some(e);
+        return -1;
+    })
 }
 
 #[no_mangle]

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -430,16 +430,18 @@ pub extern "C" fn resource_file_is_readable_by_owner(ptr: *mut File) -> int32_t 
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_readable_by_group(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_is_readable_by_group(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.is_readable_by_group().unwrap() {
-        1
-    } else {
-        0
+    match f.is_readable_by_group() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
     }
 }
 

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -219,7 +219,6 @@ pub extern "C" fn resource_file_mode(ptr: *mut File) -> int32_t {
         f.error = Some(e);
         return -1;
     })
-
 }
 
 #[no_mangle]
@@ -351,13 +350,19 @@ pub extern "C" fn resource_file_is_symlink(ptr: *mut File) -> int32_t {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_contents(ptr: *const File) -> *mut c_char {
+pub extern "C" fn resource_file_contents(ptr: *mut File) -> *const c_char {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
-    let c = f.contents().unwrap();
-    CString::new(c).unwrap().into_raw()
+
+    match f.contents() {
+        Ok(c) => CString::new(c).unwrap().into_raw(),
+        Err(e) => {
+            f.error = Some(e);
+            std::ptr::null()
+        }
+    }
 }
 
 #[no_mangle]

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -516,16 +516,18 @@ pub extern "C" fn resource_file_is_writable_by_owner(ptr: *mut File) -> int32_t 
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_writable_by_group(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_is_writable_by_group(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.is_writable_by_group().unwrap() {
-        1
-    } else {
-        0
+    match f.is_writable_by_group() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
     }
 }
 

--- a/src/resource/file.rs
+++ b/src/resource/file.rs
@@ -319,13 +319,19 @@ pub extern "C" fn resource_file_is_pipe(ptr: *mut File) -> int32_t {
 }
 
 #[no_mangle]
-pub extern "C" fn resource_file_is_socket(ptr: *const File) -> uint32_t {
+pub extern "C" fn resource_file_is_socket(ptr: *mut File) -> int32_t {
     let f = unsafe {
         assert!(!ptr.is_null());
-        &*ptr
+        &mut *ptr
     };
 
-    if f.is_socket().unwrap() { 1 } else { 0 }
+    match f.is_socket() {
+        Ok(f) => if f { 1 } else { 0 },
+        Err(e) => {
+            f.error = Some(e);
+            return -1;
+        }
+    }
 }
 
 #[no_mangle]

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -43,6 +43,15 @@ fn file_resource() {
 }
 
 #[test]
+fn file_not_exist() {
+    let b = backend::direct::Direct::new();
+    let s = specinfra::new(&b).unwrap();
+    let file = s.file("file_does_not_exist");
+
+    assert_eq!(file.exist().unwrap(), false);
+}
+
+#[test]
 #[cfg(target_os="macos")]
 fn file_link() {
     let b = backend::direct::Direct::new();


### PR DESCRIPTION
To get error description from other languages via FFI, set error objet in File struct.
