### PR TITLE
Add SSH backend (with Shell provider) support for Ubuntu platform

### DIFF
--- a/src/platform/linux/ubuntu.rs
+++ b/src/platform/linux/ubuntu.rs
@@ -14,7 +14,7 @@ pub struct Ubuntu {
     release: String,
 }
 
-fn detect_from_content(content: &str) -> Option<Box<Platform>> {
+fn detect_by_lsb_releae(content: &str) -> Option<Box<Platform>> {
     let mut lines = content.lines();
     let line = lines.next().unwrap();
     if line.starts_with("DISTRIB_ID") {
@@ -43,14 +43,14 @@ impl Platform for Ubuntu {
 
     fn inline_detector(&self) -> Option<Box<Platform>> {
         let mut file = File::open("/etc/lsb-release").unwrap();
-        let mut contents = String::new();
-        let _ = file.read_to_string(&mut contents);
-        detect_from_content(&contents)
+        let mut content = String::new();
+        let _ = file.read_to_string(&mut content);
+        detect_by_lsb_releae(&content)
     }
 
     fn shell_detector(&self, b: &Backend) -> Option<Box<Platform>> {
-        let contents = b.run_command("cat /etc/lsb-release").unwrap();
-        detect_from_content(&contents)
+        let content = b.run_command("cat /etc/lsb-release").unwrap();
+        detect_by_lsb_releae(&content)
     }
 
     fn get_provider(&self) -> Box<Provider> {

--- a/src/platform/linux/ubuntu.rs
+++ b/src/platform/linux/ubuntu.rs
@@ -1,18 +1,36 @@
 use std::fs::File;
 use std::io::prelude::*;
-use std::io::BufReader;
 
 use backend::Backend;
 use platform::platform::Platform;
 use provider::Provider;
 use provider::file::FileProvider;
 use provider::file::inline::posix::Posix;
-use provider::file::shell::null::Null;
+use provider::file::shell::linux::Linux;
 
 #[derive(Clone)]
 pub struct Ubuntu {
     name: String,
     release: String,
+}
+
+fn detect_from_content(content: &str) -> Option<Box<Platform>> {
+    let mut lines = content.lines();
+    let line = lines.next().unwrap();
+    if line.starts_with("DISTRIB_ID") {
+        let id = line.split("=").nth(1).unwrap().trim();
+        if id == "Ubuntu" {
+            let line = lines.next().unwrap();
+            let release = line.split("=").nth(1).unwrap();
+            let u = Ubuntu {
+                name: id.to_string(),
+                release: release.to_string(),
+            };
+
+            return Some(Box::new(u));
+        }
+    }
+    None
 }
 
 impl Platform for Ubuntu {
@@ -24,35 +42,21 @@ impl Platform for Ubuntu {
     }
 
     fn inline_detector(&self) -> Option<Box<Platform>> {
-        let file = File::open("/etc/lsb-release").unwrap();
-        let mut reader = BufReader::new(file);
-        let mut line = String::new();
-        let _ = reader.read_line(&mut line);
-        if line.starts_with("DISTRIB_ID") {
-            let id = line.split("=").nth(1).unwrap().trim();
-            if id == "Ubuntu" {
-                let mut line = String::new();
-                let _ = reader.read_line(&mut line);
-                let release = line.split("=").nth(1).unwrap();
-                let u = Ubuntu {
-                    name: id.to_string(),
-                    release: release.to_string(),
-                };
-
-                return Some(Box::new(u));
-            }
-        }
-        None
+        let mut file = File::open("/etc/lsb-release").unwrap();
+        let mut contents = String::new();
+        let _ = file.read_to_string(&mut contents);
+        detect_from_content(&contents)
     }
 
-    fn shell_detector(&self, _: &Backend) -> Option<Box<Platform>> {
-        None
+    fn shell_detector(&self, b: &Backend) -> Option<Box<Platform>> {
+        let contents = b.run_command("cat /etc/lsb-release").unwrap();
+        detect_from_content(&contents)
     }
 
     fn get_provider(&self) -> Box<Provider> {
         let fp = FileProvider {
             inline: Box::new(Posix),
-            shell: Box::new(Null),
+            shell: Box::new(Linux),
         };
 
         let p = Provider { file: Box::new(fp) };

--- a/src/provider/file/shell/linux.rs
+++ b/src/provider/file/shell/linux.rs
@@ -1,0 +1,22 @@
+use std::result::Result;
+
+use backend::Backend;
+use provider::error::Error;
+use provider::Output;
+use provider::file::shell::ShellProvider;
+
+#[derive(Clone)]
+pub struct Linux;
+
+impl ShellProvider for Linux {
+    fn mode(&self, name: &str, b: &Backend) -> Result<Output, Error> {
+        let c = format!("stat -c %a {}", name);
+        let res = try!(b.run_command(&c));
+        let m = try!(i32::from_str_radix(&res, 8));
+        Ok(Output::I32(m))
+    }
+
+    fn box_clone(&self) -> Box<ShellProvider> {
+        Box::new((*self).clone())
+    }
+}

--- a/src/provider/file/shell/mod.rs
+++ b/src/provider/file/shell/mod.rs
@@ -90,4 +90,5 @@ impl Clone for Box<ShellProvider> {
 }
 
 pub mod bsd;
+pub mod linux;
 pub mod null;


### PR DESCRIPTION
本文日本語で失礼します。

Python bindingでSSH backendの実装と動作確認をした所、まだ未サポートのようでしたので実装してみました。Python bindingからですが動作確認済みです。

Rustがまだまだ分からなくて見よう見まねなので、拙い所があると思いますがよければご確認よろしくお願いします！ @mizzy 