### PR TITLE
Add test for shell provider

### DIFF
--- a/src/provider/file/inline/mod.rs
+++ b/src/provider/file/inline/mod.rs
@@ -1,29 +1,86 @@
 use provider::Output;
 use provider::error::Error;
+use provider::error::HandleFuncNotDefined;
 use provider::file::Whom;
 
 // See https://users.rust-lang.org/t/solved-is-it-possible-to-clone-a-boxed-trait-object/1714/6
 
 pub trait InlineProvider {
-    fn is_file(&self, &str) -> Result<Output, Error>;
-    fn exist(&self, &str) -> Result<Output, Error>;
-    fn is_directory(&self, &str) -> Result<Output, Error>;
-    fn is_block_device(&self, &str) -> Result<Output, Error>;
-    fn is_character_device(&self, &str) -> Result<Output, Error>;
-    fn is_pipe(&self, &str) -> Result<Output, Error>;
-    fn is_socket(&self, &str) -> Result<Output, Error>;
-    fn is_symlink(&self, &str) -> Result<Output, Error>;
-    fn contents(&self, &str) -> Result<Output, Error>;
-    fn mode(&self, &str) -> Result<Output, Error>;
-    fn owner(&self, &str) -> Result<Output, Error>;
-    fn group(&self, &str) -> Result<Output, Error>;
-    fn linked_to(&self, &str) -> Result<Output, Error>;
-    fn is_readable(&self, &str, Option<&Whom>) -> Result<Output, Error>;
-    fn is_writable(&self, &str, Option<&Whom>) -> Result<Output, Error>;
-    fn md5sum(&self, &str) -> Result<Output, Error>;
-    fn sha256sum(&self, &str) -> Result<Output, Error>;
-    fn selinux_label(&self, &str) -> Result<Output, Error>;
-    fn size(&self, &str) -> Result<Output, Error>;
+    fn mode(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn size(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn is_file(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn is_directory(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn is_block_device(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn is_character_device(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn is_pipe(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn is_socket(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn is_symlink(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn exist(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn contents(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn owner(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn group(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn linked_to(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn is_readable(&self, &str, Option<&Whom>) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn is_writable(&self, &str, Option<&Whom>) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn md5sum(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn sha256sum(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
+
+    fn selinux_label(&self, &str) -> Result<Output, Error> {
+        Err(From::from(HandleFuncNotDefined))
+    }
 
     fn box_clone(&self) -> Box<InlineProvider>;
 }
@@ -35,3 +92,4 @@ impl Clone for Box<InlineProvider> {
 }
 
 pub mod posix;
+pub mod null;

--- a/src/provider/file/inline/null.rs
+++ b/src/provider/file/inline/null.rs
@@ -1,0 +1,10 @@
+use provider::file::inline::InlineProvider;
+
+#[derive(Clone)]
+pub struct Null;
+
+impl InlineProvider for Null {
+    fn box_clone(&self) -> Box<InlineProvider> {
+        Box::new((*self).clone())
+    }
+}

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -1,12 +1,50 @@
 extern crate specinfra;
 
 use specinfra::backend;
+use specinfra::Specinfra;
+// use specinfra::provider::file::inline::null::Null;
 
 #[test]
 #[cfg(any(target_os="macos", target_os="linux"))]
-fn file_resource() {
+fn file_resource_with_inline_provider() {
     let b = backend::direct::Direct::new();
     let s = specinfra::new(&b).unwrap();
+    test_file_resource(s);
+}
+
+#[test]
+fn file_not_exist_with_inline_provider() {
+    let b = backend::direct::Direct::new();
+    let s = specinfra::new(&b).unwrap();
+    test_file_not_exit(s);
+}
+
+// #[test]
+// fn file_not_exist_with_shell_provider() {
+// let b = backend::direct::Direct::new();
+// let mut s = specinfra::new(&b).unwrap();
+// s.provider.file.inline = Box::new(Null);
+// test_file_not_exit(s);
+// }
+//
+
+#[test]
+#[cfg(target_os="macos")]
+fn file_link_on_macos_with_inline_provider() {
+    let b = backend::direct::Direct::new();
+    let s = specinfra::new(&b).unwrap();
+    test_file_link_on_macos(s);
+}
+
+#[test]
+#[cfg(target_os="linux")]
+fn file_link_with_inline_provder_for_linux() {
+    let b = backend::direct::Direct::new();
+    let s = specinfra::new(&b).unwrap();
+    test_file_link_on_linux(s);
+}
+
+fn test_file_resource(s: Specinfra) {
     let file = s.file("/etc/passwd");
 
     assert_eq!(file.mode().unwrap(), 0o644);
@@ -42,32 +80,20 @@ fn file_resource() {
     assert!(file.size().unwrap() > 0);
 }
 
-#[test]
-fn file_not_exist() {
-    let b = backend::direct::Direct::new();
-    let s = specinfra::new(&b).unwrap();
+fn test_file_not_exit(s: Specinfra) {
     let file = s.file("file_does_not_exist");
-
     assert_eq!(file.exist().unwrap(), false);
 }
 
-#[test]
 #[cfg(target_os="macos")]
-fn file_link() {
-    let b = backend::direct::Direct::new();
-    let s = specinfra::new(&b).unwrap();
+fn test_file_link_on_macos(s: Specinfra) {
     let file = s.file("/etc");
-
     assert_eq!(file.linked_to().unwrap(), "private/etc");
 }
 
-#[test]
 #[cfg(target_os="linux")]
-fn file_link() {
-    let b = backend::direct::Direct::new();
-    let s = specinfra::new(&b).unwrap();
+fn test_file_link_on_linux(s: Specinfra) {
     let file = s.file("/var/lock");
-
     let link = file.linked_to().unwrap();
     assert!(link == "/run/lock" || link == "../run/lock");
 }


### PR DESCRIPTION
And add Null provider of file::inline provider.

Direct backend switches back to a shell provider if functions not defined in an inline provider.

So if you set Null inline provider to specinfra object, direct backend uses shell provider instead of inline provider.