### PR TITLE
[WIP] Change SSH backend interface to a struct with pubkey/password

### DIFF
--- a/src/backend/ssh.rs
+++ b/src/backend/ssh.rs
@@ -139,7 +139,6 @@ use backend::BackendWrapper;
 
 #[no_mangle]
 pub extern "C" fn backend_ssh_new(s: *const SSHInterface) -> *mut BackendWrapper {
-    // let target = unsafe { &*s };
     let s = SSHBuilder::new().set_target(s).finalize().unwrap();
     let b = BackendWrapper { backend: Box::new(s) };
     Box::into_raw(Box::new(b))


### PR DESCRIPTION
ref: #43 

Sorry for writing in Japanese 🙇 

とりあえず、最低限の動作確認までできたのでご相談したいこともあったので送らせていただきます。
下記についてご意見いただきたく 🙇 

現状の悩みとしては、以下のようなものです。

- cffiからnullableな値を受け取る方法が分からなかったので未指定項目は空文字列という仕様
  - 私的な基準ではありますが、ここはまだ許容できる
- できればポートも指定できるようにしたい
  - ポートの未指定時が例えば `0` や `-1` というように定義したとして、内部で `22` に置き換わるというのはイマイチ
  - かといって、SSHのポートを変えたいケースは多くはないので `22` を渡させるというインターフェースは避けたい

現状では以下を考えています

1. cffiからnullableな値を受け取る方法を引き続き模索する
2. ポートを変えたい場合はhostnameに `:2222` のように含ませる仕様とする
3. ポートについては現状は必須ではないので一旦無しで入れる