### PR TITLE
Change SSH backend interface to a structure for pubkey/password authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ md5 = "0.3.5"
 sha2 = "0.6.0"
 nix = "0.9.0"
 dbus = { version = "0.5.4", optional = true }
+regex = "0.2.2"
 
 [lib]
 name = "specinfra"

--- a/src/backend/ssh.rs
+++ b/src/backend/ssh.rs
@@ -139,7 +139,6 @@ use backend::BackendWrapper;
 
 #[no_mangle]
 pub extern "C" fn backend_ssh_new(s: *const SSHInterface) -> *mut BackendWrapper {
-    // let target = unsafe { &*s };
     let s = SSHBuilder::new().set_target(s).finalize().unwrap();
     let b = BackendWrapper { backend: Box::new(s) };
     Box::into_raw(Box::new(b))

--- a/src/backend/ssh.rs
+++ b/src/backend/ssh.rs
@@ -1,10 +1,10 @@
 pub extern crate ssh2;
 
-use libc::{c_char,c_uint};
+use libc::c_char;
 use std::ffi::CStr;
+use regex::Regex;
 
 use std::result::Result;
-use std::str;
 use std::net::TcpStream;
 use std::io::prelude::*;
 use std::path::Path;
@@ -30,7 +30,6 @@ pub struct SSHInterface {
     user: *const c_char,
     password: *const c_char,
     key_file: *const c_char,
-    port: *const c_uint,
 }
 
 pub struct SSHBuilder {
@@ -38,7 +37,6 @@ pub struct SSHBuilder {
     user: String,
     password: String,
     key_file: String,
-    port: u32,
 }
 
 impl SSHBuilder {
@@ -48,7 +46,6 @@ impl SSHBuilder {
             user: "".to_string(),
             password: "".to_string(),
             key_file: "".to_string(),
-            port: 22
         }
     }
 
@@ -65,8 +62,14 @@ impl SSHBuilder {
 
     pub fn finalize(self) -> Result<SSH, Error> {
         let hostname = self.hostname;
-        let port = self.port.to_string();
-        let remote_addr = hostname + ":" + &port;
+        let re = Regex::new(r":\d+$").unwrap();
+        let remote_addr: String;
+        if re.is_match(&hostname) {
+            remote_addr = hostname;
+        } else {
+            remote_addr = hostname + ":22";
+        }
+
         let user = self.user;
         let password = self.password;
         let key_file = self.key_file;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ extern crate users;
 extern crate md5;
 extern crate sha2;
 extern crate nix;
+extern crate regex;
 
 use std::ffi::CStr;
 


### PR DESCRIPTION
Change the argument of `backend_ssh_new ` to a structure with hostname, user and pubkey or password.

- Interface definition

```rust
pub struct SSHInterface {
    hostname: *const c_char,
    user: *const c_char,
    password: *const c_char,
    key_file: *const c_char,
}
```

**If you do not give specific properties, use the empty string.**

Sample Code (Python binding)

```python
import libspecinfra
import libspecinfra.backend
import ctypes

class SSHInterfaceS(ctypes.Structure):
    _fields_ = [
            ("hostname", ctypes.c_char_p),
            ("user", ctypes.c_char_p),
            ("password", ctypes.c_char_p),
            ("key_file", ctypes.c_char_p)]

    def __init__(self, **kwargs):
        self.hostname = kwargs.get('hostname', "").encode('utf-8')
        self.user = kwargs.get('user', "").encode('utf-8')
        self.password = kwargs.get('password', "").encode('utf-8')
        self.key_file = kwargs.get('key_file', "").encode('utf-8')

t = SSHInterfaceS(
    hostname='ec2-11-111-111-111.us-west-2.compute.amazonaws.com',
    user='ubuntu',
    key_file='/Users/marcy/.ssh/example.pem')

backend = libspecinfra.backend.SSH(t)
specinfra = libspecinfra.Specinfra(backend)
f = specinfra.file('/etc/passwd')

print(oct(f.mode())) # => 0o644
```

Note : #59 (My thought process. Sorry for writing in Japanese)