### PR TITLE
Mask mode by 0o7777 because of incompatible change of Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,4 @@ rust:
   - stable
   - beta
   - nightly
-matrix:
-  allow_failures:
-    - rust: beta
-    - rust: nightly
+

--- a/src/provider/file/inline/posix.rs
+++ b/src/provider/file/inline/posix.rs
@@ -82,7 +82,8 @@ impl Posix {
 
 impl InlineProvider for Posix {
     fn mode(&self, name: &str) -> Result<Output, Error> {
-        let res = try!(fs::metadata(name).map(|m| Output::I32(m.permissions().mode() as i32)));
+        let res = try!(fs::metadata(name)
+            .map(|m| Output::I32((m.permissions().mode() & 0o7777) as i32)));
         Ok(res)
     }
 


### PR DESCRIPTION
See:
 * https://github.com/rust-lang/rust/pull/44625
 * https://github.com/rust-lang/rust/issues/45330